### PR TITLE
78-gon125

### DIFF
--- a/programmers/42747/swift/gon125.swift
+++ b/programmers/42747/swift/gon125.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+func solution(_ citations:[Int]) -> Int {
+    let sortedCitations = citations.sorted(by: >)
+    let hIndexMax = min(citations.count, sortedCitations.first!)
+    guard hIndexMax != 0 else { return 0 }
+    return (1...hIndexMax).reversed().first(where: { sortedCitations[$0-1] >= $0 })!
+}


### PR DESCRIPTION
<!-- 제목형식: 이슈번호-아이디 ex) 10-gon125 -->
<!-- 자동 이슈링킹 방법: 본문 아무곳에 키워드 #이슈번호를 추가한다. ex) closes #10 -->
closes #78 
## 문제 :memo:
- H-Index

## 풀이방법 :mag:
- 정렬 한 뒤, hIndex의 min, max 값이 어떨지 생각해보면 0...전체길이 혹은 0...제일인용많이된 횟수 라는 걸 깨닫게 된다.
- 그래서 max 값을 지정하고 max 부터 1씩 내려가면서 조건 만족하는 첫번째 h 찾으면 그게 hIndex가 된다.
- 여기서 조건은 h 이상 인용된 논문 h개 이상이기 때문에, 정렬array[h-1]의 값이 h보가 크거나 같다는 말과 똑같음을 알 수 있음

<!-- 시간 복잡도를 적고 산출 근거를 대략 적어봅시다.-->
## 시간복잡도는 얼마? ⏰🤑💰
- O(nlogn)
- 소팅하는 시간이 젤 많이 걸린다. 나머지는 n 이하

## 정답화면 :camera:
<img width="1440" alt="Screen Shot 2021-03-26 at 11 09 36 PM" src="https://user-images.githubusercontent.com/20037035/112646984-63bf1e80-8e8b-11eb-855f-e06b587f7308.png">