### PR TITLE
100-yeollow

### DIFF
--- a/programmers/42842/java/yeollow.java
+++ b/programmers/42842/java/yeollow.java
@@ -1,0 +1,20 @@
+// https://programmers.co.kr/learn/courses/30/lessons/42842
+public class Solution{
+    public int[] solution(int brown, int yellow) {
+        int[] answer = {};
+        int sum = brown + yellow;
+        for (int i = 3; i <= sum; i++) {
+            if (sum % i == 0) {
+                int col = sum / i;
+                int row = sum / col;
+
+                int x = col - 2;
+                int y = row - 2;
+                if (x * y == yellow && x >= y)
+                    answer = new int[]{col, row};
+            }
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
<!-- 제목형식: 이슈번호-아이디 ex) 10-gon125 -->
<!-- 자동 이슈링킹 방법: 본문 아무곳에 키워드 #이슈번호를 추가한다. ex) closes #10 -->
## 문제 :memo:
- 카펫

## 풀이방법 :mag:
- 약수
- 개인적으로.. 완전탐색과는 거리가 멀어 보였음.
- 타일의 가로는 항상 3보다 크거나 같음을 이용하여, brown과 yeollow를 더한 sum까지 반복하여 sum의 약수쌍을 구함
- 약수쌍 x,y는 각 -2씩 하면 yeollow의 가로, 세로 길이이므로, x*y가 yeollow와 같음을 보이고, 가로가 세로보다 길다는 조건이 문제에 있으니, x>=y를 만족시키는 약수쌍을 반환.

<!-- 시간 복잡도를 적고 산출 근거를 대략 적어봅시다.-->
## 시간복잡도는 얼마? ⏰🤑💰
- O(n) : 최악의 경우 brown과 yeollow가 최댓값으로 같을 때, 2n번 반복하나 O(n)으로 표기

## 정답화면 :camera:
![스크린샷, 2021-04-03 02-18-28](https://user-images.githubusercontent.com/47915704/113438146-f24f1500-9422-11eb-883f-acea5341de39.png)