### PR TITLE
116-gon125

### DIFF
--- a/programmers/42861/swift/gon125.swift
+++ b/programmers/42861/swift/gon125.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+func solution(_ n:Int, _ costs:[[Int]]) -> Int {
+    let costs = costs.sorted { $0[2] < $1[2] }
+    var uf = UnionFind(size: n)
+    
+    var minCost = 0
+    var count = 0
+    for cost in costs {
+        if !uf.areInSameSet(cost[0], cost[1]) {
+            minCost += cost[2]
+            uf.union(cost[0], cost[1])
+            count += 1
+        }
+        if count == n - 1 { break }
+    }
+    return minCost
+}
+
+struct UnionFind {
+    var parent: [Int]
+    
+    init(size n: Int) {
+       parent = Array(0..<n)
+    }
+    
+    public func areInSameSet(_ a: Int, _ b: Int) -> Bool {
+        return parentOf(a) == parentOf(b)
+    }
+    
+    public mutating func union(_ a: Int, _ b: Int) {
+        let parentOfA = parentOf(a)
+        let parentOfB = parentOf(b)
+        parent[parentOfB] = parentOfA
+    }
+    
+    private func parentOf(_ a: Int) -> Int {
+        if a == parent[a] { return a }
+        return parentOf(parent[a])
+    }
+}


### PR DESCRIPTION
<!-- 제목형식: 이슈번호-아이디 ex) 10-gon125 -->
<!-- 자동 이슈링킹 방법: 본문 아무곳에 키워드 #이슈번호를 추가한다. ex) closes #10 -->
## 문제 :memo:
closes #116 
- 
## 풀이방법 :mag:
- 그래프 모든 정점 연결하는 최소 간선 비용 찾기 -> 방향그래프 아님. 
- 모든 간선 비용을 기준으로 정렬
- union find를 통해 모든 정점이 하나의 집합에 존재하면 모두 연결됨
- 이때 종료 조건은 n-1 번의 union을 시행할 때.

<!-- 시간 복잡도를 적고 산출 근거를 대략 적어봅시다.-->
## 시간복잡도는 얼마? ⏰🤑💰
- 모든 간선 비용을 기준으로 정렬 (nlogn)
- 이때 종료 조건은 n-1 번의 union을 시행할 때. (n)
nlogn

## 정답화면 :camera:

<!-- 정답화면 스크린샷을 포함해주세요!-->

<img width="769" alt="Screen Shot 2021-05-15 at 4 09 44 PM" src="https://user-images.githubusercontent.com/20037035/118351621-f761c100-b597-11eb-8a1d-71c9ea2941fb.png">
